### PR TITLE
Added text extension to core.

### DIFF
--- a/src/Extension/TextExtension.php
+++ b/src/Extension/TextExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Faker\Core\Extension;
+
+/**
+ * @experimental This interface is experimental and does not fall under our BC promise
+ */
+interface TextExtension extends Extension
+{
+    /**
+     * Generate a text string by the Markov chain algorithm.
+     *
+     * Depending on the $max, returns a random valid looking text. The algorithm
+     * generates a weighted table with the specified number of words as the index and the
+     * possible following words as the value.
+     *
+     * @example 'Alice, swallowing down her flamingo, and began by taking the little golden key'
+     *
+     * @param int $min Minimum number of characters the text should contain
+     * @param int $max Maximum number of characters the text should contain
+     * @param int $indexSize  Determines how many words are considered for the generation of the next word.
+     *                        The minimum is 1, and it produces a higher level of randomness, although the
+     *                        generated text usually doesn't make sense. Higher index sizes (up to 5)
+     *                        produce more correct text, at the price of less randomness.
+     */
+    public function realText(int $min = 0, int $max = 200, int $indexSize = 2): string;
+}


### PR DESCRIPTION
Added the text extension. I removed the proxy method "realText" where it was a proxy to "realTextBetween". Guess the last one alone is fine during a migration. It has the same options and has some extra features this way