### PR TITLE
Added implementation for the country extension

### DIFF
--- a/src/Container/ContainerBuilder.php
+++ b/src/Container/ContainerBuilder.php
@@ -10,6 +10,7 @@ use Faker\Core\Implementation;
 use Faker\Core\Extension\BarcodeExtension;
 use Faker\Core\Extension\BloodExtension;
 use Faker\Core\Extension\ColorExtension;
+use Faker\Core\Extension\CountryExtension;
 use Faker\Core\Extension\DateTimeExtension;
 use Faker\Core\Extension\FileExtension;
 use Faker\Core\Extension\NumberExtension;
@@ -67,6 +68,7 @@ final class ContainerBuilder
             BarcodeExtension::class => Implementation\Barcode::class,
             BloodExtension::class => Implementation\Blood::class,
             ColorExtension::class => Implementation\Color::class,
+            CountryExtension::class => Implementation\Country::class,
             DateTimeExtension::class => Implementation\DateTime::class,
             FileExtension::class => Implementation\File::class,
             LanguageExtension::class => Implementation\Language::class,

--- a/src/DefaultGenerator.php
+++ b/src/DefaultGenerator.php
@@ -7,6 +7,7 @@ use Faker\Core\Container\ContainerInterface;
 use Faker\Core\Extension\BarcodeExtension;
 use Faker\Core\Extension\BloodExtension;
 use Faker\Core\Extension\ColorExtension;
+use Faker\Core\Extension\CountryExtension;
 use Faker\Core\Extension\DateTimeExtension;
 use Faker\Core\Extension\Extension;
 use Faker\Core\Extension\ExtensionNotFound;
@@ -24,6 +25,7 @@ use Faker\Core\Strategy\StrategyInterface;
  * @mixin BarcodeExtension
  * @mixin BloodExtension
  * @mixin ColorExtension
+ * @mixin CountryExtension
  * @mixin DateTimeExtension
  * @mixin FileExtension
  * @mixin NumberExtension
@@ -197,7 +199,7 @@ class DefaultGenerator
 
     public function __call(string $name, array $arguments)
     {
-        return $this->strategy->generate($name, fn() => $this->format($name, $arguments));
+        return $this->strategy->generate($name, fn () => $this->format($name, $arguments));
     }
 
     public function __destruct()

--- a/src/Extension/CountryExtension.php
+++ b/src/Extension/CountryExtension.php
@@ -8,11 +8,6 @@ namespace Faker\Core\Extension;
 interface CountryExtension extends Extension
 {
     /**
-     * @example 'Japan'
-     */
-    public function country(): string;
-
-    /**
      * @example 'FR'
      * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
      */

--- a/src/Implementation/Country.php
+++ b/src/Implementation/Country.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Faker\Core\Implementation;
+
+use Faker\Core\Extension\CountryExtension;
+use Faker\Core\Extension\Helper;
+
+final class Country implements CountryExtension
+{
+    /**
+     * @var string[]
+     * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+     * On date of 2014-10-19
+     */
+    private array $alpha2 = [
+        'AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'AO', 'AQ', 'AR',
+        'AS', 'AT', 'AU', 'AW', 'AX', 'AZ', 'BA', 'BB', 'BD', 'BE',
+        'BF', 'BG', 'BH', 'BI', 'BJ', 'BL', 'BM', 'BN', 'BO', 'BQ',
+        'BR', 'BS', 'BT', 'BW', 'BY', 'BZ', 'CA', 'CC', 'CD', 'CF',
+        'CG', 'CH', 'CI', 'CK', 'CL', 'CM', 'CN', 'CO', 'CR', 'CU',
+        'CV', 'CW', 'CX', 'CY', 'CZ', 'DE', 'DJ', 'DK', 'DM', 'DO',
+        'DZ', 'EC', 'EE', 'EG', 'EH', 'ER', 'ES', 'ET', 'FI', 'FJ',
+        'FK', 'FM', 'FO', 'FR', 'GA', 'GB', 'GD', 'GE', 'GF', 'GG',
+        'GH', 'GI', 'GL', 'GM', 'GN', 'GP', 'GQ', 'GR', 'GS', 'GT',
+        'GU', 'GW', 'GY', 'HK', 'HN', 'HR', 'HT', 'HU', 'ID', 'IE',
+        'IL', 'IM', 'IN', 'IO', 'IQ', 'IR', 'IS', 'IT', 'JE', 'JM',
+        'JO', 'JP', 'KE', 'KG', 'KH', 'KI', 'KM', 'KN', 'KP', 'KR',
+        'KW', 'KY', 'KZ', 'LA', 'LB', 'LC', 'LI', 'LK', 'LR', 'LS',
+        'LT', 'LU', 'LV', 'LY', 'MA', 'MC', 'MD', 'ME', 'MF', 'MG',
+        'MH', 'MK', 'ML', 'MM', 'MN', 'MO', 'MP', 'MQ', 'MR', 'MS',
+        'MT', 'MU', 'MV', 'MW', 'MX', 'MY', 'MZ', 'NA', 'NC', 'NE',
+        'NF', 'NG', 'NI', 'NL', 'NO', 'NP', 'NR', 'NU', 'NZ', 'OM',
+        'PA', 'PE', 'PF', 'PG', 'PH', 'PK', 'PL', 'PM', 'PN', 'PR',
+        'PS', 'PT', 'PW', 'PY', 'QA', 'RE', 'RO', 'RS', 'RU', 'RW',
+        'SA', 'SB', 'SC', 'SD', 'SE', 'SG', 'SH', 'SI', 'SJ', 'SK',
+        'SL', 'SM', 'SN', 'SO', 'SR', 'SS', 'ST', 'SV', 'SX', 'SY',
+        'SZ', 'TC', 'TD', 'TF', 'TG', 'TH', 'TJ', 'TK', 'TL', 'TM',
+        'TN', 'TO', 'TR', 'TT', 'TV', 'TW', 'TZ', 'UA', 'UG', 'UM',
+        'US', 'UY', 'UZ', 'VA', 'VC', 'VE', 'VG', 'VI', 'VN', 'VU',
+        'WF', 'WS', 'YE', 'YT', 'ZA', 'ZM', 'ZW',
+    ];
+
+    /**
+     * @var string[]
+     * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
+     * On date of 2014-10-19
+     */
+    private array $alpha3 = [
+        'ABW', 'AFG', 'AGO', 'AIA', 'ALA', 'ALB', 'AND', 'ARE', 'ARG', 'ARM',
+        'ASM', 'ATA', 'ATF', 'ATG', 'AUS', 'AUT', 'AZE', 'BDI', 'BEL', 'BEN',
+        'BES', 'BFA', 'BGD', 'BGR', 'BHR', 'BHS', 'BIH', 'BLM', 'BLR', 'BLZ',
+        'BMU', 'BOL', 'BRA', 'BRB', 'BRN', 'BTN', 'BVT', 'BWA', 'CAF', 'CAN',
+        'CCK', 'CHE', 'CHL', 'CHN', 'CIV', 'CMR', 'COD', 'COG', 'COK', 'COL',
+        'COM', 'CPV', 'CRI', 'CUB', 'CUW', 'CXR', 'CYM', 'CYP', 'CZE', 'DEU',
+        'DJI', 'DMA', 'DNK', 'DOM', 'DZA', 'ECU', 'EGY', 'ERI', 'ESH', 'ESP',
+        'EST', 'ETH', 'FIN', 'FJI', 'FLK', 'FRA', 'FRO', 'FSM', 'GAB', 'GBR',
+        'GEO', 'GGY', 'GHA', 'GIB', 'GIN', 'GLP', 'GMB', 'GNB', 'GNQ', 'GRC',
+        'GRD', 'GRL', 'GTM', 'GUF', 'GUM', 'GUY', 'HKG', 'HMD', 'HND', 'HRV',
+        'HTI', 'HUN', 'IDN', 'IMN', 'IND', 'IOT', 'IRL', 'IRN', 'IRQ', 'ISL',
+        'ISR', 'ITA', 'JAM', 'JEY', 'JOR', 'JPN', 'KAZ', 'KEN', 'KGZ', 'KHM',
+        'KIR', 'KNA', 'KOR', 'KWT', 'LAO', 'LBN', 'LBR', 'LBY', 'LCA', 'LIE',
+        'LKA', 'LSO', 'LTU', 'LUX', 'LVA', 'MAC', 'MAF', 'MAR', 'MCO', 'MDA',
+        'MDG', 'MDV', 'MEX', 'MHL', 'MKD', 'MLI', 'MLT', 'MMR', 'MNE', 'MNG',
+        'MNP', 'MOZ', 'MRT', 'MSR', 'MTQ', 'MUS', 'MWI', 'MYS', 'MYT', 'NAM',
+        'NCL', 'NER', 'NFK', 'NGA', 'NIC', 'NIU', 'NLD', 'NOR', 'NPL', 'NRU',
+        'NZL', 'OMN', 'PAK', 'PAN', 'PCN', 'PER', 'PHL', 'PLW', 'PNG', 'POL',
+        'PRI', 'PRK', 'PRT', 'PRY', 'PSE', 'PYF', 'QAT', 'REU', 'ROU', 'RUS',
+        'RWA', 'SAU', 'SDN', 'SEN', 'SGP', 'SGS', 'SHN', 'SJM', 'SLB', 'SLE',
+        'SLV', 'SMR', 'SOM', 'SPM', 'SRB', 'SSD', 'STP', 'SUR', 'SVK', 'SVN',
+        'SWE', 'SWZ', 'SXM', 'SYC', 'SYR', 'TCA', 'TCD', 'TGO', 'THA', 'TJK',
+        'TKL', 'TKM', 'TLS', 'TON', 'TTO', 'TUN', 'TUR', 'TUV', 'TWN', 'TZA',
+        'UGA', 'UKR', 'UMI', 'URY', 'USA', 'UZB', 'VAT', 'VCT', 'VEN', 'VGB',
+        'VIR', 'VNM', 'VUT', 'WLF', 'WSM', 'YEM', 'ZAF', 'ZMB', 'ZWE',
+    ];
+
+    public function countryISOAlpha2(): string
+    {
+        return Helper::randomElement($this->alpha2);
+    }
+
+    public function countryISOAlpha3(): string
+    {
+        return Helper::randomElement($this->alpha3);
+    }
+}


### PR DESCRIPTION
I removed the country names from the interface where it is localized.

The only thing im thinking about how we are going to handle this since the country names is something we want to serve.

@bram-pkg maybe we should revert this and make a seperate ISO interface? Or should we not make this final and keep the country names in so that localized extensions can implement the remaining method?